### PR TITLE
Test with Rubinius on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: ruby
 rvm:
   - 2.0.0
   - 1.9.3
-  - rbx-19mode
+  - rbx-nightly-19mode
   - jruby-19mode
+allow_failures:
+  - rvm: rbx-nightly-19mode


### PR DESCRIPTION
The tests are passing on Rubinius in 1.9 mode. I've added allow_failures in case you decide to use Ruby 2.0 syntax, but I hope you'll stick with 1.9 syntax until we get the Ruby 2.0 parser into Rubinius, which should be in the not-too-distant future.
