### PR TITLE
Change `merge` from a class method to an  instance method

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ end
 You can combine two streams together:
 
 ```ruby
-merged_stream = Frappuccino::Stream.merge(stream_one, stream_two)
+merged_stream = stream_one.merge(stream_two)
+
+# or
+
+merged_stream = Frappuccino::Stream.merge(one_stream , other_stream)
 
 # or
 

--- a/lib/frappuccino/stream.rb
+++ b/lib/frappuccino/stream.rb
@@ -90,6 +90,10 @@ module Frappuccino
       callbacks << blk
     end
 
+    def merge(another_stream)
+      self.class.new(self, another_stream)
+    end
+
     def self.merge(stream_one, stream_two)
       new(stream_one, stream_two)
     end

--- a/test/map_test.rb
+++ b/test/map_test.rb
@@ -29,7 +29,7 @@ describe "map" do
     stream_one = Frappuccino::Stream.new(plus_button)
     stream_two = Frappuccino::Stream.new(minus_button)
 
-    merged_stream = Frappuccino::Stream.merge(stream_one, stream_two)
+    merged_stream = stream_one.merge(stream_two)
     mapped_stream = to_array(merged_stream.map(:+ => 1, :- => -1, :default => 0))
 
     assert_equal [], mapped_stream
@@ -48,7 +48,7 @@ describe "map" do
     stream_one = Frappuccino::Stream.new(plus_button)
     stream_two = Frappuccino::Stream.new(minus_button)
 
-    merged_stream = Frappuccino::Stream.merge(stream_one, stream_two)
+    merged_stream = stream_one.merge(stream_two)
     mapped_stream = to_array(merged_stream.map(:default => 1))
 
     assert_equal [], mapped_stream

--- a/test/merge_test.rb
+++ b/test/merge_test.rb
@@ -7,7 +7,7 @@ describe "merging steams" do
 
     stream_one = Frappuccino::Stream.new(button_one)
     stream_two = Frappuccino::Stream.new(button_two)
-    merged_stream = to_array(Frappuccino::Stream.merge(stream_one, stream_two))
+    merged_stream = to_array(stream_one.merge(stream_two))
 
     button_one.push
     button_two.push
@@ -21,8 +21,7 @@ describe "merging steams" do
 
     stream_one = Frappuccino::Stream.new(plus_button)
     stream_two = Frappuccino::Stream.new(minus_button)
-
-    merged_stream = Frappuccino::Stream.merge(stream_one, stream_two)
+    merged_stream = stream_one.merge(stream_two)
     counter = merged_stream
               .map do |event|
                 case event
@@ -49,5 +48,22 @@ describe "merging steams" do
 
     4.times { plus_button.push }
     assert_equal 2, counter.now
+  end
+end
+
+
+describe "merging stream with Frappuccino::Stream#merge" do
+  it "produces one stream with both sets of events" do
+    button_one = Button.new
+    button_two = Button.new
+
+    stream_one = Frappuccino::Stream.new(button_one)
+    stream_two = Frappuccino::Stream.new(button_two)
+    merged_stream = to_array(Frappuccino::Stream.merge(stream_one, stream_two))
+
+    button_one.push
+    button_two.push
+
+    assert_equal 2, merged_stream.length
   end
 end


### PR DESCRIPTION
Change `merge` from a class method to an  instance method to act a bit similar to others.
