### PR TITLE
Add lazy #map operation to Property

### DIFF
--- a/lib/frappuccino/property.rb
+++ b/lib/frappuccino/property.rb
@@ -1,22 +1,31 @@
 module Frappuccino
   class Property
+  end
+end
+
+require 'frappuccino/property/map_property'
+
+module Frappuccino
+  class Property
     def initialize(zero, stream)
       @value = zero
-      stream.add_observer(self)
+      stream.on_value do |value|
+        @value = value
+      end
     end
 
     def now
       @value
     end
 
-    def update(value)
-      @value = value
-    end
-
     def sample(stream)
       stream.map do
         self.now
       end
+    end
+
+    def map(&blk)
+      MapProperty.new(self, &blk)
     end
   end
 end

--- a/lib/frappuccino/property/map_property.rb
+++ b/lib/frappuccino/property/map_property.rb
@@ -1,0 +1,12 @@
+module Frappuccino
+  class MapProperty < Property
+    def initialize(property, &block)
+      @property = property
+      @block = block
+    end
+
+    def now
+      @block.call(@property.now)
+    end
+  end
+end

--- a/test/mvp_test.rb
+++ b/test/mvp_test.rb
@@ -10,13 +10,14 @@ describe "MVP interaction" do
     counter = stream
               .map {|event| event == :pushed ? 1 : 0 }
               .inject(0) {|sum, n| sum + n }
+              .map { |val| val.to_s }
 
-    assert_equal 0, counter.now
+    assert_equal "0", counter.now
 
     3.times { button.push }
-    assert_equal 3, counter.now
+    assert_equal "3", counter.now
 
     button.push
-    assert_equal 4, counter.now
+    assert_equal "4", counter.now
   end
 end

--- a/test/property_test.rb
+++ b/test/property_test.rb
@@ -43,4 +43,19 @@ describe "Property" do
       assert_equal @samples, [0, 1]
     end
   end
+
+  describe "#map" do
+    it "creates a Property with a mapped value of the original" do
+      button = CounterButton.new(1)
+      stream = Frappuccino::Stream.new(button)
+      prop = Frappuccino::Property.new("0", stream).map do |v|
+        v.to_s
+      end
+
+      5.times do |i|
+        assert_equal i.to_s, prop.now
+        button.push
+      end
+    end
+  end
 end


### PR DESCRIPTION
I thought it would be nice to be able to perform a lazy map on a Property. This is basically the same as doing a #map on a Stream and then using it to create a Property but can provide a nicer abstraction. 

I thought it would make more sense for it to be lazy as we don't need to apply the map function until we actually query the Property (as we don't push the changes in value anywhere).
