### PR TITLE
Don't call .now anymore

### DIFF
--- a/lib/frappuccino/property.rb
+++ b/lib/frappuccino/property.rb
@@ -27,5 +27,9 @@ module Frappuccino
     def map(&blk)
       MapProperty.new(self, &blk)
     end
+
+    def to_ary
+      [now]
+    end
   end
 end


### PR DESCRIPTION
I had this idea @ Euruko after i asked you a question.

``` ruby
class Button
  def push
    emit "anything"
  end
end

button = Button.new

stream = Frappuccino::Stream.new(button).map{ |event| 1 }.inject(0) { |sum, e| sum +=e }
button.push

s1 = stream

puts s1 # => 1
button.push
s2 = stream
puts s2 # => 2

push button
puts stream #=> 3
```
