### PR TITLE
Fix #merge for calls on Stream sub classes

### DIFF
--- a/lib/frappuccino/stream.rb
+++ b/lib/frappuccino/stream.rb
@@ -91,7 +91,7 @@ module Frappuccino
     end
 
     def merge(another_stream)
-      self.class.new(self, another_stream)
+      Stream.new(self, another_stream)
     end
 
     def self.merge(stream_one, stream_two)

--- a/test/merge_test.rb
+++ b/test/merge_test.rb
@@ -49,6 +49,18 @@ describe "merging steams" do
     4.times { plus_button.push }
     assert_equal 2, counter.now
   end
+  
+  it "works if the callee has a different constructor from Stream" do
+    button_one = Button.new
+    button_two = Button.new
+
+    stream_one = Frappuccino::Stream.new(button_one).map { 0 }
+    stream_two = Frappuccino::Stream.new(button_two)
+    
+    # This would explode if the merge was calling
+    # self.class.new rather than Stream.new
+    stream_one.merge(stream_two)
+  end
 end
 
 


### PR DESCRIPTION
Before calling #merge on `Map` for example would explode as `Map`'s constructor is not the same as `Stream` and the code was doing `self.class.new` rather than `Stream.new`.
