### PR TITLE
Stream#reduce is aliased to Stream#inject

### DIFF
--- a/lib/frappuccino/stream.rb
+++ b/lib/frappuccino/stream.rb
@@ -73,6 +73,7 @@ module Frappuccino
     def inject(start, &blk)
       Property.new(start, self.scan(start, &blk))
     end
+    alias :reduce :inject
 
     def select(&blk)
       Select.new(self, &blk)

--- a/test/inject_test.rb
+++ b/test/inject_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+describe "reduce" do
+  it "is a synonym for #inject" do
+    button = Button.new
+    stream = Frappuccino::Stream.new(button)
+
+    counter = stream.map(:default => 1)
+                  .reduce(0) { |sum, n| sum + n }
+
+    assert_equal 0, counter.now
+
+    3.times { button.push }
+    assert_equal 3, counter.now
+
+    button.push
+    assert_equal 4, counter.now
+  end
+end


### PR DESCRIPTION
We alias detect -> find and collect -> map probably to match standard(?) functional programming vocabulary, adding an alias for reduce/inject as well.
